### PR TITLE
Original function random_number generates in the interval [0,1], we n…

### DIFF
--- a/navier.f90
+++ b/navier.f90
@@ -552,9 +552,9 @@ call random_seed(put = code+63946*nrank*(/ (i - 1, i = 1, ii) /)) !
    do k=1,xsize(3)
    do j=1,xsize(2)
    do i=1,xsize(1)
-      ux1(i,j,k)=noise*ux1(i,j,k)
-      uy1(i,j,k)=noise*uy1(i,j,k)
-      uz1(i,j,k)=noise*uz1(i,j,k)
+      ux1(i,j,k)=noise*(ux1(i,j,k)*2-1)
+      uy1(i,j,k)=noise*(uy1(i,j,k)*2-1)
+      uz1(i,j,k)=noise*(uz1(i,j,k)*2-1)
    enddo
    enddo
    enddo


### PR DESCRIPTION
…eed [-1,1]
WInc3D has a random noise generator, that seeds the initial flow with random noise scaled to a desired intensity in order to trigger the development of turbulence. It was observed, however, that after the initialization the flow exhibited a pronounced bias in the positive horizontal direction (z direction).  
The problem has been found to be a bug in the noise generator. The function random_number should generate values with a distribution centred in zero and in the interval [-1,1], but was generating values in the interval [0,1]. The source code file navier.f90 was modified and the correct behaviour was established.