### PR TITLE
Fix blade length

### DIFF
--- a/acl_turb.f90
+++ b/acl_turb.f90
@@ -91,7 +91,7 @@ contains
     
     turbine%blade(iblade)%COR(1:3)=turbine%origin(1:3)
     turbine%blade(iblade)%L=turbine%Rmax
-    turbine%blade(iblade)%NElem=Nstations-1 
+    turbine%blade(iblade)%NElem=Nstations
     
     do istation=1,Nstations
     turbine%blade(iblade)%QCx(istation)=rR(istation)*turbine%Rmax*Svec(1)!+turbine%blade(iblade)%COR(1)+turbine%dist_from_axis
@@ -186,7 +186,7 @@ contains
     turbine%tower%name=trim(turbine%name)//'_tower'
    
     turbine%Tower%COR=turbine%origin
-    turbine%Tower%NElem=Nstations-1  
+    turbine%Tower%NElem=Nstations 
     turbine%Tower%L=turbine%Towerheight
 
     do istation=1,Nstations
@@ -424,7 +424,7 @@ contains
 
 
     do j=1,turbine%NBlades
-        do ielem=1,turbine%Blade(j)%Nelem+1
+        do ielem=1,turbine%Blade(j)%Nelem
         ! Blade end locations (quarter chord). xBE(MaxSegEnds)
         xtmp=turbine%Blade(j)%QCx(ielem)
         ytmp=turbine%Blade(J)%QCy(ielem)

--- a/navier.f90
+++ b/navier.f90
@@ -552,9 +552,9 @@ call random_seed(put = code+63946*nrank*(/ (i - 1, i = 1, ii) /)) !
    do k=1,xsize(3)
    do j=1,xsize(2)
    do i=1,xsize(1)
-      ux1(i,j,k)=noise*ux1(i,j,k)
-      uy1(i,j,k)=noise*uy1(i,j,k)
-      uz1(i,j,k)=noise*uz1(i,j,k)
+      ux1(i,j,k)=noise*(ux1(i,j,k)*2-1)
+      uy1(i,j,k)=noise*(uy1(i,j,k)*2-1)
+      uz1(i,j,k)=noise*(uz1(i,j,k)*2-1)
    enddo
    enddo
    enddo


### PR DESCRIPTION
Running the tutorial BlindTests, that comes with the distribution of WInc3D, it was noted that the computed total length of the wind turbine blade (Total length reported: 0.434 m) does not correspond to its radius (0.45 m). The inconsistency is related to how the blade elements are computed from the information in the “blade_geom” file. This error is relevant, as not using the full length of the blade implies the calculation of the forces to be always underpredicted. After modifying the source code files acl_turb.f90 and acl_elem.f90, the correct behaviour was established (Total length reported: 0.45).
